### PR TITLE
Avoid using http_build_query

### DIFF
--- a/src/append_query_string.php
+++ b/src/append_query_string.php
@@ -59,24 +59,21 @@ function append_query_string(string $url, string $queryString, int $mode = APPEN
         $result .= $existing.'&'.$queryString;
     } else {
         preg_match_all('#([^&=]+)(=[^&]+)?#si', $existing, $existingArray);
-        preg_match_all('#([^&=]+)(=[^&]+)?#si', $queryString, $newArray);
+        preg_match_all('#([^&=]+)(=[^&]+)?#si', $queryString, $queryStringArray);
         if (APPEND_QUERY_STRING_REPLACE_DUPLICATE === $mode) {
-            $intersect = array_intersect($existingArray[1], $newArray[1]);
-            $keyMap = array_flip($newArray[1]);
+            $intersect = array_intersect($existingArray[1], $queryStringArray[1]);
+            $keyMap = array_flip($queryStringArray[1]);
             foreach ($intersect as $key => $paramName) {
-                $existing = str_replace($existingArray[0][$key], $newArray[0][$keyMap[$paramName]], $existing);
-                $queryString = str_replace($newArray[0][$keyMap[$paramName]], '', $queryString);
+                $existing = str_replace($existingArray[0][$key], $queryStringArray[0][$keyMap[$paramName]], $existing);
+                $queryString = str_replace($queryStringArray[0][$keyMap[$paramName]], '', $queryString);
             }
-            $queryString = $existing.'&'.$queryString;
         } elseif (APPEND_QUERY_STRING_SKIP_DUPLICATE === $mode) {
-            $intersect = array_intersect($newArray[1], $existingArray[1]);
+            $intersect = array_intersect($queryStringArray[1], $existingArray[1]);
             foreach ($intersect as $key => $paramName) {
-                $queryString = str_replace($newArray[0][$key], '', $queryString);
+                $queryString = str_replace($queryStringArray[0][$key], '', $queryString);
             }
-            $queryString = $existing.'&'.$queryString;
         }
-
-        $result .= trim((string) preg_replace('#&&+#i', '&', $queryString), '&');
+        $result .= trim((string) preg_replace('#&&+#i', '&', $existing.'&'.$queryString), '&');
     }
 
     // add fragment

--- a/src/append_query_string.php
+++ b/src/append_query_string.php
@@ -76,7 +76,7 @@ function append_query_string(string $url, string $queryString, int $mode = APPEN
             $queryString = $existing.'&'.$queryString;
         }
 
-        $result .= trim(preg_replace('#&&+#i', '&', $queryString), '&');
+        $result .= trim((string) preg_replace('#&&+#i', '&', $queryString), '&');
     }
 
     // add fragment

--- a/tests/AppendQueryStringTest.php
+++ b/tests/AppendQueryStringTest.php
@@ -18,6 +18,8 @@ class AppendQueryStringTest extends TestCase
         yield ['https://foo.com#aa', 'foo=bar', 'https://foo.com?foo=bar#aa'];
         yield ['https://foo.com/', 'foo=bar', 'https://foo.com/?foo=bar'];
         yield ['https://foo.com?', 'foo=bar', 'https://foo.com?foo=bar'];
+        yield ['https://foo.com?', 'foo=bar%20bar', 'https://foo.com?foo=bar%20bar'];
+        yield ['https://foo.com?', 'foo=bar+bar', 'https://foo.com?foo=bar+bar'];
         yield ['https://foo.com/page', 'foo=bar', 'https://foo.com/page?foo=bar'];
         yield ['https://foo.com/page/', 'foo=bar', 'https://foo.com/page/?foo=bar'];
         yield ['https://user:pass@foo.com/page/', 'foo=bar', 'https://user:pass@foo.com/page/?foo=bar'];
@@ -30,27 +32,43 @@ class AppendQueryStringTest extends TestCase
     {
         yield from $this->provideBaseUrls();
 
+        yield ['https://foo.com?a=b', 'foo=bar%20bar', 'https://foo.com?a=b&foo=bar%20bar'];
+        yield ['https://foo.com?a=b', 'foo=bar+bar', 'https://foo.com?a=b&foo=bar+bar'];
         yield ['https://foo.com/page?aa=bb', 'foo=bar&biz=2', 'https://foo.com/page?aa=bb&foo=bar&biz=2'];
         yield ['https://foo.com/page?aa=bb#link', 'foo=bar&biz=2', 'https://foo.com/page?aa=bb&foo=bar&biz=2#link'];
         yield ['https://foo.com/page?aa=bb', 'foo=bar&aa=2', 'https://foo.com/page?aa=bb&foo=bar&aa=2'];
+        yield ['https://foo.com/page?aa=b+b', 'foo=bar&aa=2', 'https://foo.com/page?aa=b+b&foo=bar&aa=2'];
+        yield ['https://foo.com/page?aa=b%20b', 'foo=bar&aa=2', 'https://foo.com/page?aa=b%20b&foo=bar&aa=2'];
     }
 
     public function provideModeReplace()
     {
         yield from $this->provideBaseUrls();
 
+        yield ['https://foo.com?a=b', 'foo=bar%20bar', 'https://foo.com?a=b&foo=bar%20bar'];
+        yield ['https://foo.com?a=b', 'foo=bar+bar', 'https://foo.com?a=b&foo=bar+bar'];
         yield ['https://foo.com/page?aa=bb', 'foo=bar&biz=2', 'https://foo.com/page?aa=bb&foo=bar&biz=2'];
         yield ['https://foo.com/page?aa=bb#link', 'foo=bar&biz=2', 'https://foo.com/page?aa=bb&foo=bar&biz=2#link'];
         yield ['https://foo.com/page?aa=bb', 'foo=bar&aa=2', 'https://foo.com/page?aa=2&foo=bar'];
+        yield ['https://foo.com/page?aa=b+b', 'foo=bar&aa=2', 'https://foo.com/page?aa=2&foo=bar'];
+        yield ['https://foo.com/page?aa=b%20b', 'foo=bar&aa=2', 'https://foo.com/page?aa=2&foo=bar'];
+        yield ['https://foo.com/page?aa=b+b', 'foo=bar&aa=2+2', 'https://foo.com/page?aa=2+2&foo=bar'];
+        yield ['https://foo.com/page?aa=b%20b', 'foo=bar&aa=2%202', 'https://foo.com/page?aa=2%202&foo=bar'];
     }
 
     public function provideModeSkip()
     {
         yield from $this->provideBaseUrls();
 
-        yield ['https://foo.com/page?aa=bb', 'foo=bar&biz=2', 'https://foo.com/page?foo=bar&biz=2&aa=bb'];
-        yield ['https://foo.com/page?aa=bb#link', 'foo=bar&biz=2', 'https://foo.com/page?foo=bar&biz=2&aa=bb#link'];
-        yield ['https://foo.com/page?aa=bb', 'foo=bar&aa=2', 'https://foo.com/page?foo=bar&aa=bb'];
+        yield ['https://foo.com?a=b', 'foo=bar%20bar', 'https://foo.com?a=b&foo=bar%20bar'];
+        yield ['https://foo.com?a=b', 'foo=bar+bar', 'https://foo.com?a=b&foo=bar+bar'];
+        yield ['https://foo.com/page?aa=bb', 'foo=bar&biz=2', 'https://foo.com/page?aa=bb&foo=bar&biz=2'];
+        yield ['https://foo.com/page?aa=bb#link', 'foo=bar&biz=2', 'https://foo.com/page?aa=bb&foo=bar&biz=2#link'];
+        yield ['https://foo.com/page?aa=bb', 'foo=bar&aa=2', 'https://foo.com/page?aa=bb&foo=bar'];
+        yield ['https://foo.com/page?aa=b+b', 'foo=bar&aa=2', 'https://foo.com/page?aa=b+b&foo=bar'];
+        yield ['https://foo.com/page?aa=b%20b', 'foo=bar&aa=2', 'https://foo.com/page?aa=b%20b&foo=bar'];
+        yield ['https://foo.com/page?aa=b+b', 'foo=bar&cc=2+2', 'https://foo.com/page?aa=b+b&foo=bar&cc=2+2'];
+        yield ['https://foo.com/page?aa=b%20b', 'foo=bar&cc=2%202', 'https://foo.com/page?aa=b%20b&foo=bar&cc=2%202'];
     }
 
     /**


### PR DESCRIPTION
If we are not using `http_build_query`, then there is no need to support different encoding. 

This adds a few nice regex, but the behavior is as you wound expect. 

This will fix #3 